### PR TITLE
Update to v1.0.0-beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,15 +31,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
+checksum = "fdab415d6744056100f40250a66bc430c1a46f7a02e20bc11c94c79a0f0464df"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0-soon2"
+version = "1.0.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1c1c11bbb5d807699448dacbdd68405433574201e056bfa5b90360d9dd7b49"
+checksum = "1b6da9aa7d6d1f5607b184bb207ead134df3ddc99ddb1a2d8d9915b59454d535"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -50,18 +50,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0-soon2"
+version = "1.0.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091cab3ef940dae3a8849521ed01737d540198de4623c44e1c8dde7df1de147c"
+checksum = "eb6c5b99d05fcf047bafc0fc093e8e7b7ecb63b76791f644f5dc3eca5a548de1"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0-soon2"
+version = "1.0.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c9830cfb66bc85c723af3ac00d3e9ce67eefe464a467446d5d64e6847a8694"
+checksum = "22e4b3f6933f94acdd3ddb931af4870c2002e3331a4a8b247a4ef070dd31ccb0"
 dependencies = [
  "schemars",
  "serde_json",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0-soon2"
+version = "1.0.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e7ad2e48af44ad5d2cc777751c47d8c915c48697c9f9245e47fc5d5d99c940"
+checksum = "3b7214fed59d78adc13b98e68072bf49f5273c8a6713ca98cb7784339f49ef01"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -85,19 +85,22 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0-soon2"
+version = "1.0.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df382d5793600bc3df43f2885c43b872430f72c6cace141045c1a4f7e8793b6"
+checksum = "665cf97ad42be46936f6e6739711824a9bf21c440a6c98e185a3404aef0c3b81"
 dependencies = [
  "cosmwasm-std",
  "serde",
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
+name = "cpufeatures"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crunchy"
@@ -107,9 +110,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.2"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32a398eb1ccfbe7e4f452bc749c44d38dd732e9a253f19da224c416f00ee7f4"
+checksum = "d12477e115c0d570c12a2dfd859f80b55b60ddb5075df210d3af06d133a69f45"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -129,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest",
@@ -152,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f215f706081a44cb702c71c39a52c05da637822e9c1645a50b7202689e982d"
+checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
 dependencies = [
  "const-oid",
 ]
@@ -176,9 +179,9 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713c32426287891008edb98f8b5c6abb2130aa043c93a818728fcda78606f274"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -202,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
+checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -218,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
+checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -287,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "k256"
@@ -305,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.90"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "opaque-debug"
@@ -317,9 +320,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
+checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
  "der",
  "spki",
@@ -327,18 +330,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -369,9 +372,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6ab463ae35acccb5cba66c0084c985257b797d288b6050cc2f6ac1b266cb78"
+checksum = "d7a48d098c2a7fdf5740b19deb1181b4fb8a9e68e03ae517c14cde04b5725409"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -381,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902fdfbcf871ae8f653bddf4b2c05905ddaabc08f69d32a915787e3be0d31356"
+checksum = "4a9ea2a613fe4cd7118b2bb101a25d8ae6192e1975179b67b2f17afd11e70ac8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -393,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
@@ -411,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -433,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -444,13 +447,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
  "cfg-if",
- "cpuid-bool",
+ "cpufeatures",
  "digest",
  "opaque-debug",
 ]
@@ -467,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
 dependencies = [
  "der",
 ]
@@ -495,15 +498,15 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.64"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -512,18 +515,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -532,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "uint"
@@ -550,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "version_check"
@@ -574,6 +577,6 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Currently, the Cyber bindings include:
   - Grid
     - MsgCreateRoute
     - MsgEditRoute
-    - MsgEditRouteAlias
+    - MsgEditRouteName
     - MsgDeleteRoute
   - DMN
     - MsgCreateThought
     - MsgForgetThought
-    - MsgChangeThoughtCallData
+    - MsgChangeThoughtInput
     - MsgChangeThoughtPeriod
     - MsgChangeThoughtBlock
     - MsgChangeThoughtGasPrice

--- a/contracts/std-test/Cargo.toml
+++ b/contracts/std-test/Cargo.toml
@@ -18,11 +18,11 @@ library = []
 
 [dependencies]
 cyber-std = { path = "../../packages/cyber-std", version = "0.1.0" }
-cosmwasm-std = { version = "1.0.0-soon", features = ["iterator", "staking"] }
-cosmwasm-storage = { version = "1.0.0-soon", features = ["iterator"] }
+cosmwasm-std = { version = "1.0.0-beta", features = ["iterator", "staking"] }
+cosmwasm-storage = { version = "1.0.0-beta", features = ["iterator"] }
 schemars = "0.8.1"
 thiserror = { version = "1.0.23" }
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-soon" }
+cosmwasm-schema = { version = "1.0.0-beta" }

--- a/contracts/std-test/schema/execute_msg.json
+++ b/contracts/std-test/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -112,14 +112,14 @@
         "create_energy_route": {
           "type": "object",
           "required": [
-            "alias",
-            "destination"
+            "destination",
+            "name"
           ],
           "properties": {
-            "alias": {
+            "destination": {
               "type": "string"
             },
-            "destination": {
+            "name": {
               "type": "string"
             }
           }
@@ -154,20 +154,20 @@
     {
       "type": "object",
       "required": [
-        "edit_energy_route_alias"
+        "edit_energy_route_name"
       ],
       "properties": {
-        "edit_energy_route_alias": {
+        "edit_energy_route_name": {
           "type": "object",
           "required": [
-            "alias",
-            "destination"
+            "destination",
+            "name"
           ],
           "properties": {
-            "alias": {
+            "destination": {
               "type": "string"
             },
-            "destination": {
+            "name": {
               "type": "string"
             }
           }
@@ -250,17 +250,17 @@
     {
       "type": "object",
       "required": [
-        "change_thought_call_data"
+        "change_thought_input"
       ],
       "properties": {
-        "change_thought_call_data": {
+        "change_thought_input": {
           "type": "object",
           "required": [
-            "call_data",
+            "input",
             "name"
           ],
           "properties": {
-            "call_data": {
+            "input": {
               "type": "string"
             },
             "name": {
@@ -358,15 +358,15 @@
     "Load": {
       "type": "object",
       "required": [
-        "call_data",
-        "gas_price"
+        "gas_price",
+        "input"
       ],
       "properties": {
-        "call_data": {
-          "type": "string"
-        },
         "gas_price": {
           "$ref": "#/definitions/Coin"
+        },
+        "input": {
+          "type": "string"
         }
       }
     },

--- a/contracts/std-test/schema/query_msg.json
+++ b/contracts/std-test/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/std-test/schema/sudo_msg.json
+++ b/contracts/std-test/schema/sudo_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "SudoMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/std-test/src/contract.rs
+++ b/contracts/std-test/src/contract.rs
@@ -10,8 +10,8 @@ use cyber_std::{
     Link, Trigger, Load,
     create_cyberlink_msg, create_investmint_msg,
     create_create_energy_route_msg, create_edit_energy_route_msg,
-    create_edit_energy_route_alias_msg, create_delete_energy_route_msg,
-    create_creat_thought_msg, create_forget_thought_msg, create_change_thought_call_data_msg,
+    create_edit_energy_route_name_msg, create_delete_energy_route_msg,
+    create_creat_thought_msg, create_forget_thought_msg, create_change_thought_input_msg,
     create_change_thought_period_msg, create_change_thought_block_msg,
     ParticleRankResponse, ParticlesAmountResponse, CyberlinksAmountResponse,
     ThoughtResponse, ThoughtStatsResponse, LowestFeeResponse,
@@ -63,16 +63,16 @@ pub fn execute(
         } => investmint(deps, env, info, amount, resource, length),
         ExecuteMsg::CreateEnergyRoute {
             destination,
-            alias,
-        } => create_energy_route(deps, env, info, destination, alias),
+            name,
+        } => create_energy_route(deps, env, info, destination, name),
         ExecuteMsg::EditEnergyRoute {
             destination,
             value,
         } => edit_energy_route(deps, env, info, destination, value),
-        ExecuteMsg::EditEnergyRouteAlias {
+        ExecuteMsg::EditEnergyRouteName {
             destination,
-            alias,
-        } => edit_energy_route_alias(deps, env, info, destination, alias),
+            name,
+        } => edit_energy_route_name(deps, env, info, destination, name),
         ExecuteMsg::DeleteEnergyRoute {
             destination,
         } => delete_energy_route(deps, env, info, destination),
@@ -85,10 +85,10 @@ pub fn execute(
         ExecuteMsg::ForgetThought {
             name,
         } => forget_thought(deps, env, info, name),
-        ExecuteMsg::ChangeThoughtCallData {
+        ExecuteMsg::ChangeThoughtInput {
             name,
-            call_data,
-        } => change_thought_call_data(deps, env, info, name, call_data),
+            input,
+        } => change_thought_input(deps, env, info, name, input),
         ExecuteMsg::ChangeThoughtPeriod {
             name,
             period,
@@ -172,13 +172,13 @@ pub fn create_energy_route(
     env: Env,
     _info: MessageInfo,
     destination: String,
-    alias: String,
+    name: String,
 ) -> Result<Response, ContractError> {
     let contract = env.contract.address;
     let msg = create_create_energy_route_msg(
         contract.into(),
         destination.into(),
-        alias.into(),
+        name.into(),
     );
 
     let res = Response::new()
@@ -206,18 +206,18 @@ pub fn edit_energy_route(
     Ok(res)
 }
 
-pub fn edit_energy_route_alias(
+pub fn edit_energy_route_name(
     _deps: DepsMut,
     env: Env,
     _info: MessageInfo,
     destination: String,
-    alias: String
+    name: String
 ) -> Result<Response, ContractError> {
     let contract = env.contract.address;
-    let msg = create_edit_energy_route_alias_msg(
+    let msg = create_edit_energy_route_name_msg(
         contract.into(),
         destination.into(),
-        alias.into(),
+        name.into(),
     );
 
     let res = Response::new()
@@ -282,18 +282,18 @@ pub fn forget_thought(
     Ok(res)
 }
 
-pub fn change_thought_call_data(
+pub fn change_thought_input(
     _deps: DepsMut,
     env: Env,
     _info: MessageInfo,
     name: String,
-    call_data: String,
+    input: String,
 ) -> Result<Response, ContractError> {
     let contract = env.contract.address;
-    let msg = create_change_thought_call_data_msg(
+    let msg = create_change_thought_input_msg(
         contract.into(),
         name.into(),
-        call_data.into(),
+        input.into(),
     );
 
     let res = Response::new()

--- a/contracts/std-test/src/msg.rs
+++ b/contracts/std-test/src/msg.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::Coin;
-use cyber_std::{Link, Trigger, Load, Route};
+use cyber_std::{Link, Trigger, Load};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct  InstantiateMsg {

--- a/contracts/std-test/src/msg.rs
+++ b/contracts/std-test/src/msg.rs
@@ -51,15 +51,15 @@ pub enum ExecuteMsg {
     },
     CreateEnergyRoute {
         destination: String,
-        alias: String,
+        name: String,
     },
     EditEnergyRoute {
         destination: String,
         value: Coin,
     },
-    EditEnergyRouteAlias {
+    EditEnergyRouteName {
         destination: String,
-        alias: String,
+        name: String,
     },
     DeleteEnergyRoute {
         destination: String,
@@ -73,9 +73,9 @@ pub enum ExecuteMsg {
     ForgetThought {
         name: String,
     },
-    ChangeThoughtCallData {
+    ChangeThoughtInput {
         name: String,
-        call_data: String,
+        input: String,
     },
     ChangeThoughtPeriod {
         name: String,

--- a/contracts/std-test/src/state.rs
+++ b/contracts/std-test/src/state.rs
@@ -1,5 +1,5 @@
 
-use cosmwasm_std::{Addr, Storage, Uint128};
+use cosmwasm_std::{Storage};
 use cosmwasm_storage::{
     singleton, singleton_read, ReadonlySingleton, Singleton,
 };

--- a/packages/cyber-std/Cargo.toml
+++ b/packages/cyber-std/Cargo.toml
@@ -12,11 +12,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0-soon", features = ["iterator"] }
+cosmwasm-std = { version = "1.0.0-beta", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-soon" }
+cosmwasm-schema = { version = "1.0.0-beta" }
 
 

--- a/packages/cyber-std/README.md
+++ b/packages/cyber-std/README.md
@@ -35,12 +35,12 @@ Currently, the Cyber bindings include:
   - Energy
     - MsgCreateRoute
     - MsgEditRoute
-    - MsgEditRouteAlias
+    - MsgEditRouteName
     - MsgDeleteRoute
   - DMN
     - MsgCreateThought
     - MsgForgetThought
-    - MsgChangeThoughtCallData
+    - MsgChangeThoughtInput
     - MsgChangeThoughtPeriod
     - MsgChangeThoughtBlock
     - MsgChangeThoughtGasPrice
@@ -64,11 +64,11 @@ use cyber_std::{ CyberQuerier, RankValueResponse };
 pub fn try_something(
     deps: Deps,
     _env: Env,
-    cid: String,
+    particle: String,
     ...
-) -> StdResult<RankValueResponse> {
+) -> StdResult<ParticleRankResponse> {
     let querier = CyberQuerier::new(&deps.querier);
-    let rank_value: RankValueResponse = querier.query_rank_value_by_cid(cid)?;
+    let res: ParticleRankResponse = querier.query_particle_rank(particle)?;
     ...
     Ok(res)
 }
@@ -91,7 +91,7 @@ pub fn try_something(
     env: Env,
     links: Vec<Link>,
     ...
-) -> Result<Response<CyberMsgWrapper>, ContractError> {
+) -> Result<Response, ContractError> {
     ...
     let contract_addr = env.contract.address;
     let msg: CosmosMsg<CyberMsgWrapper> = create_cyberlink_msg(contract_addr.into(), links);

--- a/packages/cyber-std/schema/cyber_msg.json
+++ b/packages/cyber-std/schema/cyber_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "CyberMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -72,15 +72,15 @@
         "create_energy_route": {
           "type": "object",
           "required": [
-            "alias",
             "destination",
+            "name",
             "source"
           ],
           "properties": {
-            "alias": {
+            "destination": {
               "type": "string"
             },
-            "destination": {
+            "name": {
               "type": "string"
             },
             "source": {
@@ -122,21 +122,21 @@
     {
       "type": "object",
       "required": [
-        "edit_energy_route_alias"
+        "edit_energy_route_name"
       ],
       "properties": {
-        "edit_energy_route_alias": {
+        "edit_energy_route_name": {
           "type": "object",
           "required": [
-            "alias",
             "destination",
+            "name",
             "source"
           ],
           "properties": {
-            "alias": {
+            "destination": {
               "type": "string"
             },
-            "destination": {
+            "name": {
               "type": "string"
             },
             "source": {
@@ -234,18 +234,18 @@
     {
       "type": "object",
       "required": [
-        "change_thought_call_data"
+        "change_thought_input"
       ],
       "properties": {
-        "change_thought_call_data": {
+        "change_thought_input": {
           "type": "object",
           "required": [
-            "call_data",
+            "input",
             "name",
             "program"
           ],
           "properties": {
-            "call_data": {
+            "input": {
               "type": "string"
             },
             "name": {
@@ -354,15 +354,15 @@
     "Load": {
       "type": "object",
       "required": [
-        "call_data",
-        "gas_price"
+        "gas_price",
+        "input"
       ],
       "properties": {
-        "call_data": {
-          "type": "string"
-        },
         "gas_price": {
           "$ref": "#/definitions/Coin"
+        },
+        "input": {
+          "type": "string"
         }
       }
     },

--- a/packages/cyber-std/schema/cyber_msg_wrapper.json
+++ b/packages/cyber-std/schema/cyber_msg_wrapper.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "CyberMsgWrapper",
-  "description": "CyberMsgWrapper is an override of CosmosMsg::Custom to show this works and can be extended in the contract",
   "type": "object",
   "required": [
     "msg_data",
@@ -32,7 +31,7 @@
       }
     },
     "CyberMsg": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -103,15 +102,15 @@
             "create_energy_route": {
               "type": "object",
               "required": [
-                "alias",
                 "destination",
+                "name",
                 "source"
               ],
               "properties": {
-                "alias": {
+                "destination": {
                   "type": "string"
                 },
-                "destination": {
+                "name": {
                   "type": "string"
                 },
                 "source": {
@@ -153,21 +152,21 @@
         {
           "type": "object",
           "required": [
-            "edit_energy_route_alias"
+            "edit_energy_route_name"
           ],
           "properties": {
-            "edit_energy_route_alias": {
+            "edit_energy_route_name": {
               "type": "object",
               "required": [
-                "alias",
                 "destination",
+                "name",
                 "source"
               ],
               "properties": {
-                "alias": {
+                "destination": {
                   "type": "string"
                 },
-                "destination": {
+                "name": {
                   "type": "string"
                 },
                 "source": {
@@ -265,18 +264,18 @@
         {
           "type": "object",
           "required": [
-            "change_thought_call_data"
+            "change_thought_input"
           ],
           "properties": {
-            "change_thought_call_data": {
+            "change_thought_input": {
               "type": "object",
               "required": [
-                "call_data",
+                "input",
                 "name",
                 "program"
               ],
               "properties": {
-                "call_data": {
+                "input": {
                   "type": "string"
                 },
                 "name": {
@@ -382,15 +381,15 @@
     "Load": {
       "type": "object",
       "required": [
-        "call_data",
-        "gas_price"
+        "gas_price",
+        "input"
       ],
       "properties": {
-        "call_data": {
-          "type": "string"
-        },
         "gas_price": {
           "$ref": "#/definitions/Coin"
+        },
+        "input": {
+          "type": "string"
         }
       }
     },

--- a/packages/cyber-std/schema/cyber_query.json
+++ b/packages/cyber-std/schema/cyber_query.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "CyberQuery",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/packages/cyber-std/schema/cyber_query_wrapper.json
+++ b/packages/cyber-std/schema/cyber_query_wrapper.json
@@ -16,7 +16,7 @@
   },
   "definitions": {
     "CyberQuery": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [

--- a/packages/cyber-std/src/lib.rs
+++ b/packages/cyber-std/src/lib.rs
@@ -8,8 +8,8 @@ pub use msg::{
     Link, Trigger, Load, Route,
     create_cyberlink_msg, create_investmint_msg,
     create_create_energy_route_msg, create_edit_energy_route_msg,
-    create_edit_energy_route_alias_msg, create_delete_energy_route_msg,
-    create_creat_thought_msg, create_forget_thought_msg, create_change_thought_call_data_msg,
+    create_edit_energy_route_name_msg, create_delete_energy_route_msg,
+    create_creat_thought_msg, create_forget_thought_msg, create_change_thought_input_msg,
     create_change_thought_period_msg, create_change_thought_block_msg,
 };
 pub use query::{

--- a/packages/cyber-std/src/msg.rs
+++ b/packages/cyber-std/src/msg.rs
@@ -21,7 +21,7 @@ pub struct Trigger {
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct Load {
-    pub call_data: String,
+    pub input: String,
     pub gas_price: Coin,
 }
 
@@ -30,7 +30,7 @@ pub struct Load {
 pub struct Route {
     pub source: String,
     pub destination: String,
-    pub alias: String,
+    pub name: String,
     pub value: Vec<Coin>,
 }
 
@@ -65,17 +65,17 @@ pub enum CyberMsg {
     CreateEnergyRoute {
         source: String,
         destination: String,
-        alias: String,
+        name: String,
     },
     EditEnergyRoute {
         source: String,
         destination: String,
         value: Coin,
     },
-    EditEnergyRouteAlias {
+    EditEnergyRouteName {
         source: String,
         destination: String,
-        alias: String,
+        name: String,
     },
     DeleteEnergyRoute {
         source: String,
@@ -92,10 +92,10 @@ pub enum CyberMsg {
         program: String,
         name: String,
     },
-    ChangeThoughtCallData {
+    ChangeThoughtInput {
         program: String,
         name: String,
-        call_data: String,
+        input: String,
     },
     ChangeThoughtPeriod {
         program: String,
@@ -144,14 +144,14 @@ pub fn create_investmint_msg(
 pub fn create_create_energy_route_msg(
     source: String,
     destination: String,
-    alias: String,
+    name: String,
 ) -> CosmosMsg<CyberMsgWrapper> {
     CyberMsgWrapper {
         route: CyberRoute::Grid,
         msg_data: CyberMsg::CreateEnergyRoute {
             source,
             destination,
-            alias,
+            name,
         },
     }
     .into()
@@ -173,17 +173,17 @@ pub fn create_edit_energy_route_msg(
     .into()
 }
 
-pub fn create_edit_energy_route_alias_msg(
+pub fn create_edit_energy_route_name_msg(
     source: String,
     destination: String,
-    alias: String,
+    name: String,
 ) -> CosmosMsg<CyberMsgWrapper> {
     CyberMsgWrapper {
         route: CyberRoute::Grid,
-        msg_data: CyberMsg::EditEnergyRouteAlias {
+        msg_data: CyberMsg::EditEnergyRouteName {
             source,
             destination,
-            alias,
+            name: name,
         },
     }
     .into()
@@ -237,17 +237,17 @@ pub fn create_forget_thought_msg(
     .into()
 }
 
-pub fn create_change_thought_call_data_msg(
+pub fn create_change_thought_input_msg(
     program: String,
     name: String,
-    call_data: String,
+    input: String,
 ) -> CosmosMsg<CyberMsgWrapper> {
     CyberMsgWrapper {
         route: CyberRoute::Dmn,
-        msg_data: CyberMsg::ChangeThoughtCallData {
+        msg_data: CyberMsg::ChangeThoughtInput {
             program,
             name,
-            call_data,
+            input,
         },
     }
     .into()

--- a/packages/cyber-std/src/msg.rs
+++ b/packages/cyber-std/src/msg.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{CosmosMsg, Coin};
+use cosmwasm_std::{CosmosMsg, Coin, CustomMsg};
 use crate::route::CyberRoute;
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, JsonSchema)]
@@ -36,7 +36,6 @@ pub struct Route {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-/// CyberMsgWrapper is an override of CosmosMsg::Custom to show this works and can be extended in the contract
 pub struct CyberMsgWrapper {
     pub route: CyberRoute,
     pub msg_data: CyberMsg,
@@ -47,6 +46,8 @@ impl Into<CosmosMsg<CyberMsgWrapper>> for CyberMsgWrapper {
         CosmosMsg::Custom(self)
     }
 }
+
+impl CustomMsg for CyberMsgWrapper{}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/packages/cyber-std/src/querier.rs
+++ b/packages/cyber-std/src/querier.rs
@@ -10,11 +10,11 @@ use crate::query::{
 };
 
 pub struct CyberQuerier<'a> {
-    querier: &'a QuerierWrapper<'a>,
+    querier: &'a QuerierWrapper<'a, CyberQueryWrapper>,
 }
 
 impl<'a> CyberQuerier<'a> {
-    pub fn new(querier: &'a QuerierWrapper) -> Self {
+    pub fn new(querier: &'a QuerierWrapper<'a, CyberQueryWrapper>) -> Self {
         CyberQuerier { querier }
     }
 


### PR DESCRIPTION
Issue with custom querier during update to latest cosmwasm v1.0.0

https://github.com/cybercongress/cw-cyber/blob/main/packages/cyber-std/src/query.rs#L10
```
 pub struct CyberQueryWrapper {
    pub route: CyberRoute,
    pub query_data: CyberQuery,
}
impl CustomQuery for CyberQueryWrapper{}
```

And queries (changed from custom_query to query during upgrade)
https://github.com/cybercongress/cw-cyber/blob/main/packages/cyber-std/src/querier.rs#L32

Now, it's built with error:
```
   --> packages/cyber-std/src/querier.rs:191:72
    |
191 |         let res: NeuronBandwidthResponse = self.querier.query(&request.into())?;
    |                                                                        ^^^^ the trait `From<CyberQueryWrapper>` is not implemented for `QueryRequest<cosmwasm_std::Empty>`
    = help: the following implementations were found:
              <QueryRequest<C> as From<BankQuery>>
              <QueryRequest<C> as From<C>>
              <QueryRequest<C> as From<WasmQuery>>
    = note: required because of the requirements on the impl of `Into<QueryRequest<cosmwasm_std::Empty>>` for `CyberQueryWrapper`
```

cosmwasm-std' CustomQuery:
https://github.com/CosmWasm/cosmwasm/blob/main/packages/std/src/query/mod.rs#L81

```
impl<C: CustomQuery> From<C> for QueryRequest<C> {
    fn from(msg: C) -> Self {
        QueryRequest::Custom(msg)
    }
}
```